### PR TITLE
handled error in new image objects

### DIFF
--- a/HPNC Website/Views/Staff.cshtml
+++ b/HPNC Website/Views/Staff.cshtml
@@ -16,7 +16,7 @@
         @foreach (var fieldset in Model.Content.GetPropertyValue<ArchetypeModel>("staffMembers"))
         {
 
-            var imageSrc = customURLHelper.UmbracoFile(Umbraco.Media(@fieldset.GetValue("image")).umbracoFile.ToString());
+            var imageSrc = customURLHelper.UmbracoFile(Umbraco.Media(@fieldset.GetValue("image")).Url.ToString());
 
             <div class="col-lg-6">
                 <div class="row">


### PR DESCRIPTION
for some reason, the object for umbraco images has changed slightly. now the umbracoImage is sometimes null but the Url property seems to do the same thing. 